### PR TITLE
Add eks statefulset manifest

### DIFF
--- a/deployments/postgres.040.statefulset.eks.all.yaml
+++ b/deployments/postgres.040.statefulset.eks.all.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: TARGET_K8S_NAMESPACE
+  labels:
+    app: postgres
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:13-alpine
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          env:
+          - name: PGDATA
+            value: /var/lib/postgresql/data/napptive/
+          envFrom:
+            - configMapRef:
+                name: postgres-config
+            - secretRef:
+                name: postgres-secret
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgredb
+  volumeClaimTemplates:
+    - metadata:
+        name: postgredb
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        # No storageClassName to use the default one.
+        # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-storage
+        # storageClassName: "standard"
+        resources:
+          requests:
+            storage: 5Gi


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?
Adds a new statefulset manifest for the eks cluster.

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?
The volume is created with a `lost+found` directory, and the init.b of the database fails when it finds a not empty folder, and the data is not `Postgres` data

```
initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
It contains a lost+found directory, perhaps due to it being a mount point.
Using a mount point directly as the data directory is not recommended.
Create a subdirectory under the mount point.
```

#### What are the associated tickets?

#### Screenshots (if appropriate)

#### Questions
