### PR TITLE
PG-1069 Enable processing sub-directories from a given path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.48
+          args: --timeout=3m

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build/
 
 # Manual testing scripts
 manual_*_test.sh
+
+.idea

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ docker-build: $(addsuffix .docker-build, $(BUILD_TARGETS))
 %.docker-build: %.docker-prep
 	@if [ -f $(DOCKER_FOLDER)/$(basename $@)/Dockerfile ]; then\
 		echo "Building docker file for "$(basename $@);\
-		$(DOCKERCMD) build $(DOCKER_FOLDER)/$(basename $@) -t $(TARGET_DOCKER_REGISTRY)/$(basename $@):$(VERSION);\
+		$(DOCKERCMD) build --platform linux/amd64 $(DOCKER_FOLDER)/$(basename $@) -t $(TARGET_DOCKER_REGISTRY)/$(basename $@):$(VERSION);\
 	fi
 
 .PHONY: docker-push

--- a/internal/app/rdbms/schema.go
+++ b/internal/app/rdbms/schema.go
@@ -18,41 +18,87 @@ package rdbms
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
-	"github.com/rs/zerolog/log"
-
+	"github.com/jackc/pgx/v4"
 	"github.com/napptive/rdbms/v2/internal/pkg/config"
 	"github.com/napptive/rdbms/v2/internal/pkg/script"
 	"github.com/napptive/rdbms/v2/pkg/operations"
 	"github.com/napptive/rdbms/v2/pkg/rdbms"
-
-	"github.com/jackc/pgx/v4"
+	"github.com/rs/zerolog/log"
 )
 
-// LoadResult store the result infomation of the load operation.
+// LoadResult store the result information of the loadFile operation.
 type LoadResult struct {
+	FileName      string
 	ExecutedSteps []string
 	SkippedSteps  []string
 }
 
 // Print write in the log the result information.
 func (r *LoadResult) Print() {
-	log.Info().Strs("executed", r.ExecutedSteps).
+	log.Info().Str("file", r.FileName).Strs("executed", r.ExecutedSteps).
 		Strs("skipped", r.SkippedSteps).
 		Msgf("Load has executed %d steps and skipped %d steps", len(r.ExecutedSteps), len(r.SkippedSteps))
 }
 
-//Load creates the basic information in the target database.
-func Load(path string, defaultTimeout time.Duration, selectedSteps []string, cfg config.Config) (*LoadResult, error) {
+// Load creates the basic information in the target database.
+func Load(path string, fileExtension string, defaultTimeout time.Duration, selectedSteps []string, cfg config.Config) ([]*LoadResult, error) {
 	r := rdbms.NewRDBMS()
-	return load(path, defaultTimeout, selectedSteps, cfg, r)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if fileInfo.IsDir() {
+		return loadDirectory(path, fileExtension, defaultTimeout, selectedSteps, cfg, r)
+	}
+	fileResult, err := loadFile(path, defaultTimeout, selectedSteps, cfg, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*LoadResult{fileResult}, nil
 }
 
-func load(path string, defaultTimeout time.Duration, selectedSteps []string, cfg config.Config, rdbms rdbms.RDBMS) (*LoadResult, error) {
+// loadDirectory processes all files matching the extension in alphabetical order.
+func loadDirectory(path string, fileExtension string, defaultTimeout time.Duration, selectedSteps []string, cfg config.Config, rdbms rdbms.RDBMS) ([]*LoadResult, error) {
+	results := make([]*LoadResult, 0)
+	log.Info().Str("dir", path).Msg("processing directory")
+	err := filepath.Walk(path,
+		func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			if err != nil {
+				return err
+			}
+
+			if !info.IsDir() && strings.HasSuffix(info.Name(), fileExtension) {
+				fileResult, err := loadFile(path, defaultTimeout, selectedSteps, cfg, rdbms)
+				if err != nil {
+					log.Error().Err(err).Str("file", path).Msg("error executing file steps")
+					return err
+				}
+				results = append(results, fileResult)
+			} else {
+				log.Debug().Str("file", path).Msg("skipping file")
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func loadFile(path string, defaultTimeout time.Duration, selectedSteps []string, cfg config.Config, rdbms rdbms.RDBMS) (*LoadResult, error) {
 	var executedSteps []string
 	var skippedSteps []string
-
+	log.Info().Str("path", path).Msg("processing file")
 	if !cfg.SkipPing {
 		if err := Ping(cfg); err != nil {
 			return nil, err
@@ -81,11 +127,12 @@ func load(path string, defaultTimeout time.Duration, selectedSteps []string, cfg
 			skippedSteps = append(skippedSteps, step.Name)
 		}
 	}
-	result := &LoadResult{ExecutedSteps: executedSteps, SkippedSteps: skippedSteps}
+	result := &LoadResult{FileName: path, ExecutedSteps: executedSteps, SkippedSteps: skippedSteps}
 	return result, nil
 }
 
 func execStep(step script.SQLStep, defaultTimeout time.Duration, conn rdbms.Conn) error {
+	log.Info().Str("step", step.Name).Msg("executing step")
 	duration, err := step.TimeoutDuration(defaultTimeout)
 	if err != nil {
 		return err

--- a/internal/app/rdbms/schema_test.go
+++ b/internal/app/rdbms/schema_test.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("Load Schema test", func() {
 	}
 
 	var connstring = "host=localhost user=postgres password=Pass2020! port=5432"
-
+	var fileExtension = ".yaml"
 	var defaultDuration = 5 * time.Second
 
 	ginkgo.It("Should work", func() {
@@ -55,11 +55,12 @@ var _ = ginkgo.Describe("Load Schema test", func() {
 				SkipPing:          false,
 			},
 		}
-		result, err := Load(filepath, defaultDuration, []string{}, cfg)
+		result, err := Load(filepath, fileExtension, defaultDuration, []string{}, cfg)
 		gomega.Expect(err).To(gomega.Succeed())
-		gomega.Expect(result.ExecutedSteps).To(gomega.HaveLen(3))
-		gomega.Expect(result.SkippedSteps).To(gomega.HaveLen(0))
-		result.Print()
+		gomega.Expect(result).Should(gomega.HaveLen(1))
+		gomega.Expect(result[0].ExecutedSteps).To(gomega.HaveLen(3))
+		gomega.Expect(result[0].SkippedSteps).To(gomega.HaveLen(0))
+		result[0].Print()
 	})
 
 	ginkgo.It("Should work", func() {
@@ -75,11 +76,12 @@ var _ = ginkgo.Describe("Load Schema test", func() {
 				SkipPing:          false,
 			},
 		}
-		result, err := Load(filepath, defaultDuration, []string{"creation-step", "drop-step"}, cfg)
+		result, err := Load(filepath, fileExtension, defaultDuration, []string{"creation-step", "drop-step"}, cfg)
 		gomega.Expect(err).To(gomega.Succeed())
-		gomega.Expect(result.ExecutedSteps).To(gomega.HaveLen(2))
-		gomega.Expect(result.SkippedSteps).To(gomega.HaveLen(1))
-		result.Print()
+		gomega.Expect(result).Should(gomega.HaveLen(1))
+		gomega.Expect(result[0].ExecutedSteps).To(gomega.HaveLen(2))
+		gomega.Expect(result[0].SkippedSteps).To(gomega.HaveLen(1))
+		result[0].Print()
 	})
 
 })

--- a/internal/pkg/script/sql.go
+++ b/internal/pkg/script/sql.go
@@ -18,16 +18,15 @@ package script
 
 import (
 	"fmt"
-	"github.com/napptive/nerrors/pkg/nerrors"
-	"github.com/rs/zerolog/log"
-	"io/ioutil"
+	"os"
 	"time"
 
+	"github.com/napptive/nerrors/pkg/nerrors"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v2"
-
 )
 
-// SQL respresents the import file to execute batch command in the database.
+// SQL represents the import file to execute batch command in the database.
 type SQL struct {
 	Steps []SQLStep `yaml:"steps,flow"`
 }
@@ -39,7 +38,7 @@ type SQLStep struct {
 	Queries []string `yaml:"queries,flow"`
 }
 
-//TimeoutDuration parses the time duration of the step.
+// TimeoutDuration parses the time duration of the step.
 func (step *SQLStep) TimeoutDuration(defaultTimeout time.Duration) (time.Duration, error) {
 	if step.Timeout == "" {
 		return defaultTimeout, nil
@@ -49,15 +48,14 @@ func (step *SQLStep) TimeoutDuration(defaultTimeout time.Duration) (time.Duratio
 
 // SQLFileParse transform a file in a script SQL struct.
 func SQLFileParse(filepath string) (*SQL, error) {
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}
 	return SQLParse(data)
 }
 
-
-func SQLParse(data []byte)  (*SQL, error){
+func SQLParse(data []byte) (*SQL, error) {
 	var result SQL
 	m := yaml.MapSlice{}
 	err := yaml.Unmarshal(data, &m)


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?

* Enable RDBMS load jobs to be given a directory, and load all files found in the different sub-directories recursively. The functionality is backward-compatible as it uses the same parameters but detects if it is a directory or a file.
* Improve overall operation logging
* Add a new parameter to look for a specific file extension

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

```yaml
        cmd:
          - "./rdbms"
          - "schema"
          - "load"
          - "--scriptLoadPath=/napptive/config/"
          - "-c=host=postgres port=5432 user=$(POSTGRES_USER) password=$(POSTGRES_PASSWORD) dbname=$(POSTGRES_DB)"
```

#### Any background context you want to provide?

* When executing a load job for development purposes it is more convenient to use a single trait to mount the configmaps.

#### What are the associated tickets?

* PG-1069

#### Screenshots (if appropriate)

#### Questions
